### PR TITLE
Add language toggle and unify layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,9 +8,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Heebo:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Eyal Izenman | איל איזנמן</h1>
-    <h2>Visual, AI Artist & Educator | אמן חזותי בינאי ומורה</h2>
+    <h1><span class="english">Eyal Izenman</span> | <span class="hebrew">איל איזנמן</span></h1>
+    <h2><span class="english">Visual, AI Artist & Educator</span> | <span class="hebrew">אמן חזותי בינאי ומורה</span></h2>
     <div class="carousel-container">
       <div class="carousel" id="carousel">
         <!-- Carousel items will be added dynamically here -->

--- a/pages/about-me.html
+++ b/pages/about-me.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="he-IL">
+<html lang="he-IL" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -166,13 +166,14 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>About Me | אודותיי</h1>
+    <h1><span class="english">About Me</span> | <span class="hebrew">אודותיי</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>I am Eyal Izenman, a visual artist and educator with a deep expertise in generative artificial intelligence. 
+        <p class="english">I am Eyal Izenman, a visual artist and educator with a deep expertise in generative artificial intelligence. 
            My work focuses on creating unique visual experiences and exploring the creative and ethical dimensions of AI.</p>
-        <p>Through my art and teaching, I strive to bridge the gap between technology and creativity, pushing the boundaries of what's possible in visual storytelling and interactive experiences.</p>
+        <p class="english">Through my art and teaching, I strive to bridge the gap between technology and creativity, pushing the boundaries of what's possible in visual storytelling and interactive experiences.</p>
         <p class="hebrew">אני איל איזנמן, אמן חזותי ומורה עם מומחיות מעמיקה בבינה מלאכותית ג'נרטיבית. עבודתי מתמקדת ביצירת חוויות חזותיות יחודיות ובחקירת הממדים היצירתיים והאתיים של בינה מלאכותית.</p>
         <p class="hebrew">באמצעות האמנות וההוראה שלי, אני שואף לגשר על הפער בין טכנולוגיה ליצירתית, תוך דחיפת גבולות האפשרי בסיפור חזותי וחוויות אינטראקטיביות.</p>
       </div>
@@ -198,5 +199,6 @@
       <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=https://wa.me/97236030603" alt="WhatsApp QR Code">
     </div>
   </div>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/above-and-beyond.html
+++ b/pages/above-and-beyond.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="he">
+<html lang="he" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -165,11 +165,13 @@
   </style>
 </head>
 <body>
-  <h1>Above and Beyond | מעל ומעבר</h1>
+  <button id="language-toggle">עברית</button>
+  <div class="container">
+  <h1><span class="english">Above and Beyond</span> | <span class="hebrew">מעל ומעבר</span></h1>
   <div class="description-container"><div class="text-container">
-  <p>Starting in music and teaching, I took a bold step into visual arts and AI, where I continue exploring new creative paths. Today, I work as a designer and video editor, teaching digital design and motion graphics, with AI as a central theme. 
+  <p class="english">Starting in music and teaching, I took a bold step into visual arts and AI, where I continue exploring new creative paths. Today, I work as a designer and video editor, teaching digital design and motion graphics, with AI as a central theme. 
 Recently, I brought together a group of experts in design, video with an inclination toward to form a creative guild and the sky is merely the way. Ad Astra!</p>
-  <p>My roots in art and music bring a hands-on, thoughtful approach to visual storytelling, blending creativity with technical skill.</p>
+  <p class="english">My roots in art and music bring a hands-on, thoughtful approach to visual storytelling, blending creativity with technical skill.</p>
   <p class="hebrew">
 התחלתי את המסע שלי במוזיקה והוראה, ועשיתי מעבר חד לעולם החזותי ולבינה מלאכותית, ואני ממשיך לגלות דרכים יצירתיות חדשות. היום אני מעצב ועורך וידאו, מלמד עיצוב דיגיטלי ותנועה, כשהבינה המלאכותית היא נושא מרכזי.
 לאחרונה גיבשתי קבוצת מומחים\ות בעיצוב, וידאו עם זיקה לבינה מלאכותית לכדי גילדה יצירתית והשמיים הם רק הדרך. Ad Astra!</p>
@@ -265,7 +267,8 @@ Recently, I brought together a group of experts in design, video with an inclina
     <div class="gallery-item">
       <img src="https://drive.google.com/thumbnail?id=1ahKplaBaKqbn6Jqt_2UOihF--EI1F_gn" alt="Artwork 4" class="thumbnail">
     </div>
-  </div>
+  </div></div>
+
   <div class="contact-info">
     <div class="contact-details">
       <a href="https://wa.me/97236030603" target="_blank">WhatsApp: +972 3 6030603</a>
@@ -273,5 +276,6 @@ Recently, I brought together a group of experts in design, video with an inclina
     </div>
     <img src="https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=https://wa.me/97236030603" alt="WhatsApp QR Code">
   </div>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/animation.html
+++ b/pages/animation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -122,11 +122,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Animation | הנפשה</h1>
+    <h1><span class="english">Animation</span> | <span class="hebrew">הנפשה</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>My passion for animation lies in the beauty of capturing the essence of a moment and stretching it beyond its natural limits...</p>
+        <p class="english">My passion for animation lies in the beauty of capturing the essence of a moment and stretching it beyond its natural limits...</p>
         <p class="hebrew">התשוקה שלי להנפשה מגיעה מתוך היכולת למתוח רגע מעל לגבולותיו ולתת ביטוי לניואנסים הקטנים ביותר.</p>
       </div>
       <div class="image-container">
@@ -207,5 +208,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/courses.html
+++ b/pages/courses.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -217,11 +217,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Courses | קורסים</h1>
+    <h1><span class="english">Courses</span> | <span class="hebrew">קורסים</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>
+        <p class="english">
           I teach various subjects that bring together my experience with artificial intelligence, creativity, and digital design. Through lessons and lectures, I cover topics ranging from the introdution to the technology, the impact of AI on society, to advanced AI-based video techniques. I offer a broad perspective that includes practical skills and philosophical insights.
         </p>
         <p class="hebrew">
@@ -407,5 +408,6 @@
       box.style.animationDuration = `${boxHeight / 15}s`;
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/deepfake.html
+++ b/pages/deepfake.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -146,11 +146,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Deep Fake | דיפ פייק</h1>
+    <h1><span class="english">Deep Fake</span> | <span class="hebrew">דיפ פייק</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>Deepfake art allows me to explore the boundaries between reality and illusion. It raises questions about authenticity, identity, and the ethics of digital manipulation.</p>
+        <p class="english">Deepfake art allows me to explore the boundaries between reality and illusion. It raises questions about authenticity, identity, and the ethics of digital manipulation.</p>
         <p class="hebrew">העיסוק באמנות דיפ פייק מאפשר לי לחקור את התמוססות הגבולות בין מציאות לבדיה. הוא מעלה שאלות על אמיתיות, זהות, והאתיקה של מניפולציה דיגיטלית .</p>
       </div>
       <div class="image-container">
@@ -234,5 +235,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/design.html
+++ b/pages/design.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -150,11 +150,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Design | עיצוב</h1>
+    <h1><span class="english">Design</span> | <span class="hebrew">עיצוב</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>I have always been passionate about design. It allows me to create impactful visual experiences that resonate deeply with audiences. My work blends aesthetics and functionality, raising questions about the role of design in our everyday lives.</p>
+        <p class="english">I have always been passionate about design. It allows me to create impactful visual experiences that resonate deeply with audiences. My work blends aesthetics and functionality, raising questions about the role of design in our everyday lives.</p>
         <p class="hebrew">תמיד הייתה לי אהבה לעיצוב. הוא מאפשר לי ליצור חוויות ויזואליות שיש להן השפעה עמוקה על הקהל. עבודתי משלבת בין אסתטיקה לפונקציונליות ומעלה שאלות על תפקיד העיצוב בחיינו היומיומיים.</p>
       </div>
       <div class="image-container">
@@ -237,5 +238,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/generative-video.html
+++ b/pages/generative-video.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -142,11 +142,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Generative Video | וידאו ג'נרטיבי</h1>
+    <h1><span class="english">Generative Video</span> | <span class="hebrew">וידאו ג'נרטיבי</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>I create memes and pop-culture-inspired art as a form of creative escape, allowing me to engage with contemporary culture in a playful yet meaningful way. This work also serves as a reflection on the aesthetic complexities of our times.</p>
+        <p class="english">I create memes and pop-culture-inspired art as a form of creative escape, allowing me to engage with contemporary culture in a playful yet meaningful way. This work also serves as a reflection on the aesthetic complexities of our times.</p>
         <p class="hebrew"> אני יוצר מימים ואמנות המושפעת מהתרבות הפופולרית כדרך יצירתית  לברוח, דרך שמאפשרת לי להיות מעורב בתרבות העכשווית באופן משעשע ומשמעותי. היצירה שלי מהווה גם התבוננות על המורכבות האסתטית של זמננו.</p>
       </div>
       <div class="image-container">
@@ -224,5 +225,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/motion-design.html
+++ b/pages/motion-design.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -176,11 +176,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Motion Design | עיצוב תנועה</h1>
+    <h1><span class="english">Motion Design</span> | <span class="hebrew">עיצוב תנועה</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>Motion design is a fundamental element for any motion graphics artist. I find a deep interest in mastering the classic principles of motion animation, often immersing myself in the nuances that make up subtle movements.</p>
+        <p class="english">Motion design is a fundamental element for any motion graphics artist. I find a deep interest in mastering the classic principles of motion animation, often immersing myself in the nuances that make up subtle movements.</p>
         <p class="hebrew">עיצוב תנועה הוא מאבות המזון של האפטריסט המצוי, אני מוצא ענין עמוק בשימוש מיטבי ביכולות של הנפשת תנועה קלאסית ומוצא את עצמי שוקע בקלות בניואנסים שמרכיבים תנועות מעודנות.</p>
       </div>
       <div class="image-container">
@@ -266,5 +267,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/shoshke-engelmaier.html
+++ b/pages/shoshke-engelmaier.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -129,10 +129,11 @@
   </style>
 </head>
 <body>
-  <h1>Shoshke Engelmaier | שושקה (זאב) אנגלמאיר</h1>
+  <button id="language-toggle">עברית</button>
+  <h1><span class="english">Shoshke Engelmaier</span> | <span class="hebrew">שושקה (זאב) אנגלמאיר</span></h1>
   <div class="description-container">
     <div class="text-container">
-      <p>I began creating these animations with the desire to extend the moment that Shoshke had drawn, allowing for a sense of presence with those abducted in Gaza. Through animation, I aim to bring back the presence and provide a space where the viewer can share a moment with those who are held captive.</p>
+      <p class="english">I began creating these animations with the desire to extend the moment that Shoshke had drawn, allowing for a sense of presence with those abducted in Gaza. Through animation, I aim to bring back the presence and provide a space where the viewer can share a moment with those who are held captive.</p>
       <p class="hebrew">התחלתי ליצור את ההנפשות האלו מתוך רצון למשוך את הרגע ששושקה צייר, לכדי שהות עם החטופים בעזה. דרך ההנפשה, אני שואף להשיב את הנוכחות ולאפשר לצופה לחלוק רגע עם אלו שנמצאים בשבי.</p>
     </div>
     <div class="image-container">
@@ -228,5 +229,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/visual-art.html
+++ b/pages/visual-art.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -130,11 +130,12 @@
   </style>
 </head>
 <body>
+  <button id="language-toggle">עברית</button>
   <div class="container">
-    <h1>Visual Art | אמנות חזותית</h1>
+    <h1><span class="english">Visual Art</span> | <span class="hebrew">אמנות חזותית</span></h1>
     <div class="description-container">
       <div class="text-container">
-        <p>I create visual art in a classicistic manner, drawing inspiration from traditional techniques and aesthetics. My series "Drawing Inspiration" adopts the appearance of watercolors, while conveying a deep exploration of artistic themes. Through delicate strokes and subtle hues, I evoke timeless emotions and blend classical beauty with modern artistic insight.</p>
+        <p class="english">I create visual art in a classicistic manner, drawing inspiration from traditional techniques and aesthetics. My series "Drawing Inspiration" adopts the appearance of watercolors, while conveying a deep exploration of artistic themes. Through delicate strokes and subtle hues, I evoke timeless emotions and blend classical beauty with modern artistic insight.</p>
         <p class="hebrew">אני יוצר אמנות חזותית בסגנון קלאסיציסטי, בהשראת טכניקות ואסתטטיקה מסורתיות. הסדרה שלי "Drawing Inspiration" מאופיינת במרא המזכיר צבעי מים, תוך העברת חקירה עמוקה של נושאים אמנותיים. באמצעות משיכות עדינות וגוונים רכים, אני מעורר רגשות נצחיים ומשלב יופי קלאסי עם חדר אמנותית עכשווית.</p>
       </div>
       <div class="image-container">
@@ -186,5 +187,6 @@
       gallery.appendChild(galleryItem);
     });
   </script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -28,6 +28,23 @@ let touchStartTime;
 const TAP_THRESHOLD = 10;
 const TAP_TIMEOUT = 200;
 
+// Language toggle functionality
+const languageToggle = document.getElementById('language-toggle');
+function setLanguage(lang) {
+  document.documentElement.setAttribute('data-lang', lang);
+  localStorage.setItem('lang', lang);
+  if (languageToggle) {
+    languageToggle.textContent = lang === 'en' ? 'עברית' : 'English';
+  }
+}
+
+if (languageToggle) {
+  languageToggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-lang') || 'en';
+    setLanguage(current === 'en' ? 'he' : 'en');
+  });
+}
+
 function createCarouselItems() {
   items.forEach((item, i) => {
     const element = document.createElement('div');
@@ -210,6 +227,8 @@ function startFloatingQuotes() {
 
 // Start the carousel and floating quotes when the page loads
 window.addEventListener('load', () => {
+  const savedLang = localStorage.getItem('lang') || 'en';
+  setLanguage(savedLang);
   createCarouselItems();
   updateCarousel();
   startFloatingQuotes();

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,23 @@ body {
   align-items: center;
 }
 
+#language-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 8px 12px;
+  background-color: #333;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 1001;
+}
+
+#language-toggle:hover {
+  background-color: #555;
+}
+
 h1 {
   font-size: 2.5em;
   font-weight: 700;
@@ -39,9 +56,9 @@ h2 {
 .carousel-container {
   perspective: 1000px;
   perspective-origin: 50% -35%;
-  width: 45%;
-  max-width: 800px;
-  height: 300px;
+  width: 55%;
+  max-width: 900px;
+  height: 360px;
   position: relative;
   margin: 40px auto;
 }
@@ -149,6 +166,14 @@ h2 {
   z-index: 10;
 }
 
+html[data-lang="en"] .hebrew {
+  display: none;
+}
+
+html[data-lang="he"] .english {
+  display: none;
+}
+
 #floating-quotes-container {
   position: fixed;
   top: 0;
@@ -217,7 +242,7 @@ h2 {
   }
 
   .carousel-container {
-    width: 90%;
+    width: 100%;
   }
 
   .contact-info a {


### PR DESCRIPTION
## Summary
- enlarge home page carousel
- introduce language toggle support
- hide Hebrew or English text depending on language
- add toggle button across pages and script to load preference
- wrap Above and Beyond page in `.container`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a6825ed708328a684ee39591410dd